### PR TITLE
fix: formatting corrections in Markdown template

### DIFF
--- a/OLS-application-template.md
+++ b/OLS-application-template.md
@@ -64,7 +64,7 @@ _Comma-separated list of keywords that best describe the research and interest a
 
 _Describe your project in a maximum of 200 words. You can use MarkDown formatting (see:[ https://commonmark.org/help/](https://commonmark.org/help/))._
 
-&lt;your answer>
+<your answer>
 
 ***Problem**
 

--- a/OLS-application-template.md
+++ b/OLS-application-template.md
@@ -122,8 +122,10 @@ _What do you expect from a mentor? Please respond in a maximum of 200 words. You
 
 <your answer>
 
-*Other OLS applications
+***Other OLS applications**
+
 Have you applied to OLS before, or are you applying as an author on more than one project in this round of applications? If yes, please share the project name and which round(s) you applied to OLS in, e.g. "OLS-5, Open Science Writing Guide".
+
 <your answer>
 
 


### PR DESCRIPTION
- Fix rendering for `<` in the Markdown template for the application
- Add spacing and fix formatting for the `*Other OLS applications` section